### PR TITLE
hover style for supported elements

### DIFF
--- a/hoverStyle.css
+++ b/hoverStyle.css
@@ -1,0 +1,8 @@
+.skills-pane-mouseover:hover {
+    outline: 1px solid #c53131;
+    outline-offset: -2px;
+}
+
+.primary-box-mouseover:hover {
+    outline: 1px solid #c53131;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
             "https://www.dndbeyond.com/profile/*/characters/*", "http://www.dndbeyond.com/*"
         ],
         "run at": "document_end",
+        "css": ["hoverStyle.css"],
         "js": ["content.js"]
     }
     ],


### PR DESCRIPTION
Users need a visual cue telling them which elements on their character sheet will allow them to click for a dice roll.

This feature makes a hover style for the primary box (spells, attacks, etc.) and the skills box (Athletics, Arcana, etc.)

In order to accomplish this, the chrome extension manifest now refers to a new hoverstyle.css document that will be injected into the character sheet.