### PR TITLE
Spells box

### DIFF
--- a/hoverStyle.css
+++ b/hoverStyle.css
@@ -1,0 +1,8 @@
+.skills-pane-mouseover:hover {
+    outline: 1px solid #c53131;
+    outline-offset: -2px;
+}
+
+.primary-box-mouseover:hover {
+    outline: 1px solid #c53131;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
             "https://www.dndbeyond.com/profile/*/characters/*", "http://www.dndbeyond.com/*"
         ],
         "run at": "document_end",
+        "css": ["hoverStyle.css"],
         "js": ["content.js"]
     }
     ],


### PR DESCRIPTION
This commit adds support for spells in the primary box.

The spells feature also has support for advantage rolls. Users can hold <shift> while clicking to return a roll at advantage.

It turns out that spells have effects that are only displayed in the sidebar.

So there will need to be dice rolling support in the sidebar. 