### PR TITLE
update wip title

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "chromeroller",
+    "name": "dicemagic.beyond",
     "version": "1.0",
     "description": "Rolls dice using Aaron's API while using dndbeyond",
     "permissions": [


### PR DESCRIPTION
Updates manifest to reflect current working title.

This change is reflected in the chrome extensions page and whenever the browser references the extension title.