### PR TITLE
adds sidebar spell support

### DIFF
--- a/hoverStyle.css
+++ b/hoverStyle.css
@@ -6,3 +6,15 @@
 .primary-box-mouseover:hover {
     outline: 1px solid #c53131;
 }
+
+.sidebar-damage-box {
+    all: initial;
+    outline: 1px solid #c53131;
+    outline-offset: -1px;
+    background-color: #c53131;
+}
+
+.ct-sidebar-inner {
+    all: initial;
+    background-color: #c53131;
+}


### PR DESCRIPTION
This commit adds support for clicking on damage rolls for spells in the sidebar.

It works great for spell attacks and spells with a save. 

**Open issues with this commit:**
Edge cases:
- magic missile
- magic weapon
- absorb elements
- ice knife

Hoverstyle is not working on sidebar. For that matter, no injected css seems to work on the sidebar.