### PR TITLE
Firefox port

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -466,7 +466,7 @@ async function attackAndDamageRoll(e, type) {
 
         let cmdString = `1d20,1d20,${damageDice},${damageDiceAdvantage}`
         let rolls = await getRoll(cmdString)
-        let damageRolls = rolls.result.match(/(?<=\()[\d, ]+/g)
+        let damageRolls = rolls.result.match(/[\d, ]+(?=\()/g)
         damageRolls = damageRolls[damageRolls.length - 1]
         rolls = rolls.result.match(/\d+(?=\*)/g)
         // handle to hit
@@ -760,9 +760,9 @@ async function rollSpellPrimaryBox(e) {
         console.log({effectDice, effectModifier})
         const numEffectDice = parseInt(effectDice.split('d')[0])
         console.log({numEffectDice})
-        const effectResult = roll.result.match(/(?<=\*)\d+/g)[0]
+        const effectResult = roll.result.match(/\d+(?=\*)/g)[0]
         console.log({effectResult})
-        const rawEffect = roll.result.match(/(?<=\()[\d, ]+/g)[0]
+        const rawEffect = roll.result.match(/[\d, ]+(?=\()/g)[0]
         const spellInfo = {
             spellName,
             saveDC,
@@ -979,9 +979,9 @@ async function rollSpellSideBar(e) {
     
         let roll = await getRoll(effectDice);
         console.log(roll.result)
-        console.log(roll.result.match(/(?<=\*)\d+/g))
-        let result = roll.result.match(/(?<=\*)\d+/g)[0];
-        let raw = roll.result.match(/(?<=\()[\d, ]+/g)
+        console.log(roll.result.match(/\d+(?=\*)/g))
+        let result = roll.result.match(/\d+(?=\*)/g)[0];
+        let raw = roll.result.match(/[\d, ]+(?=\()/g)
     
         return renderSideBarSpell({ spellName, effectDice, result, raw, damageType }, 'sidebar-spell-effect')
     }

--- a/js/content.js
+++ b/js/content.js
@@ -88,19 +88,6 @@ function determineAdvantage(e) {
     return 0
 }
 
-// listener for receiving messages from extension
-chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
-        console.log(sender.tab ? 
-            "from a content script:" + sender.tab.url :
-            "from the extension");
-        console.log('request', request)
-
-        if (request.command) {
-            sendResponse({status: 'got the message'})
-        }
-})
-
 // get rolls from background script
 function getRoll(cmd) {
     console.log('getting roll')

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,7 @@
     "version": "1.0",
     "description": "Rolls dice using Aaron's API while using dndbeyond",
     "permissions": [
-        "activeTab", 
-        "declarativeContent", 
+        "activeTab",
         "https://www.dndbeyond.com/",
         "https://api.dicemagic.io/"
     ],
@@ -14,7 +13,7 @@
         "matches": [
             "https://www.dndbeyond.com/profile/*/characters/*", "http://www.dndbeyond.com/*"
         ],
-        "run at": "document_end",
+        "run_at": "document_end",
         "css": ["css/hoverstyle.css", "css/displayboxstyle.css"],
         "js": ["js/content.js"]
     }


### PR DESCRIPTION
**Resolves #23: Firefox Port**

Now works as a Firefox WebExtension. I will look up how to get it signed and distributed later this weekend. In the meantime, you may download and load as a temporary add-on

Had to remove the regex lookbehinds, as they are specified in ECMA 2018 and supported in chrome but not Firefox yet.

Also removed incompatible permissions from manifest. Turns out they were holdovers from earlier in development.